### PR TITLE
fix: 日記詳細ページのいいねボタンの位置調整。非同期後の位置ずれ解消

### DIFF
--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -56,7 +56,7 @@
         <%= diary.title %>
       </div>
     <% end %>
-    <div id="like-<%=diary.id%>" class="flex pt-3">
+    <div id="like-<%=diary.id%>" class="flex">
       <%= button_to likes_path(diary_id: diary.id), id: "btn_animation", method: { turbo_method: :post } do %>
         <% if diary.likes_count >= 0 && diary.likes_count < 500 %>
           <div class="btn0">

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:title, @diary.title) %>
-<div class="container pt-5">
+<div class="container pt-5 pl-5">
   <div class="user-name text-center text-black font-bold text-2xl">
     <%= @diary.user.name %>
   </div>
   <div class="flex items-end">
     <%= render partial: "show_diary", locals: {diary: @diary} %>
   </div>
-  <div id="like-<%=@diary.id%>" class="flex pl-20 pt-0">
+  <div id="like-<%=@diary.id%>" class="flex">
     <%= button_to likes_path(diary_id: @diary.id), id: "btn_animation", method: { turbo_method: :post } do %>
         <% if @diary.likes_count >= 0 && @diary.likes_count < 500 %>
           <div class="btn0">

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.replace "like-#{@diary.id}" do %>
-  <div id="like-<%=@diary.id%>" class="flex pt-0">
+  <div id="like-<%=@diary.id%>" class="flex">
     <%= button_to likes_path(diary_id: @diary.id), id: "btn_animation", method: { turbo_method: :post } do %>
         <% if @diary.likes_count >= 0 && @diary.likes_count < 500 %>
           <div class="btn0">


### PR DESCRIPTION
## 概要
* いいねボタン押したときの非同期変化後に、ボタンの位置がズレる問題を解消
* create.turbo_stream.erbのplクラス定義が余計に書いてあったことが原因だったため、削除した。