### PR TITLE
update: 連続日数処理に一つ前の日記とcreated_atの範囲が同じ場合の分岐を追加。日記作成フォームなどに使用しているDateク…

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -16,7 +16,7 @@ class LikesController < ApplicationController
   end
 
   def everything
-    @today_diaries = Diary.where(diary_date: Date.today).includes(:user)
+    @today_diaries = Diary.where(diary_date: Time.zone.today).includes(:user)
     @diaries = Diary.includes(:user).with_likes_count.order(diary_date: :desc)
     if @today_diaries.present?
       @today_diaries.each do |diary|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,7 +73,10 @@ class User < ApplicationRecord
       logger.info "message::::diary: #{diary.inspect}"
       if diary.created_at.between?((Time.zone.today - past_count.day).beginning_of_day, (Time.zone.today - past_count.day).end_of_day)
         past_count += 1
+      elsif diary.created_at.between?((Time.zone.today - (past_count - 1).day).beginning_of_day, (Time.zone.today - (past_count - 1).day).end_of_day)
+        logger.info "message::::Same created_at date as the previous diary"
       else
+        logger.info "message::::each loop break"
         break
       end
     end

--- a/app/views/diaries/_form.html.erb
+++ b/app/views/diaries/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: @diary, class: "w-full max-w-3xl mx-auto" do |f| %>
   <div class="mb-3">
     <%= f.label :diary_date %>
-    <%= f.date_field :diary_date, class: "input input-bordered input-success", value: Date.today %>
+    <%= f.date_field :diary_date, class: "input input-bordered input-success", value: Time.zone.today %>
   </div>
   <div class="mb-3">
     <%= f.label :title %>

--- a/app/views/diaries/new.html.erb
+++ b/app/views/diaries/new.html.erb
@@ -1,11 +1,9 @@
 <% content_for(:title, t("title.new_diary")) %>
+<%= render partial: "shared/error_messages", locals:{object: @diary} %>
 <div class="container">
   <div class="row">
     <div class="flex items-center justify-center">
       <h1><%= t("title.new_diary") %></h1>
-    </div>
-    <div class="flex justify-center">
-      <%= render partial: "shared/error_messages", locals:{object: @diary} %>
     </div>
     <div class="flex items-center justify-center mx-5">
       <%= render partial: "form", locals:{button: "保存"} %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if object.errors.any? %>
-  <div id="error_explanation" class="flex justify-center alert alert-danger">
+  <div id="error_explanation" class="flex w-full justify-center alert alert-danger">
     <ul class="mb-0">
       <% object.errors.each do |error| %>
         <li><%= error.full_message %></li>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,6 +22,6 @@ User.ids
 
 10.times do |index|
   user = User.find(11)
-  diary = user.diaries.create!(title: "今日は連勤#{index}日目だった", body: "まだまだ#{index}日ぐらい頑張れそう！", diary_date: Date.today)
+  diary = user.diaries.create!(title: "今日は連勤#{index}日目だった", body: "まだまだ#{index}日ぐらい頑張れそう！", diary_date: Time.zone.today)
   puts "\"#{diary.title}\" has created!"
 end


### PR DESCRIPTION
…ラスを使ったtodayメソッドを、Time.zone.todayに変更

## 概要
* 連続投稿数カウントメソッドで、一個前の日記とcreated_atの範囲が同じ場合の分岐を追加したことにより、同じ日に違うdiary_dateの日記を作成した場合でも失敗しない処理に改善
* 日記作成フォームのdiary_date設定フォームなどの一部ががDate.todayを使用しており、Dateクラスのタイムゾーンは変更しておらずUTCの日付だったため、Time.zone.todayに変更してJSTに対応