### PR TITLE
fix: アバターのサイズ調整ミスを修正

### DIFF
--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -13,13 +13,13 @@
       <% when 1 %>
         <div class="w-16 h-16 rounded-full bg-yellow-400"></div>
       <% when 2 %>
-        <div class="w-20 h-20 rounded-full bg-sky-500"></div>
+        <div class="w-16 h-16 rounded-full bg-sky-500"></div>
       <% when 3 %>
-        <div class="w-20 h-20 rounded-full bg-rose-600"></div>
+        <div class="w-16 h-16 rounded-full bg-rose-600"></div>
       <% when 4 %>
-        <div class="w-20 h-20 rounded-full bg-fuchsia-700"></div>
+        <div class="w-16 h-16 rounded-full bg-fuchsia-700"></div>
       <% when 5 %>
-        <div class="w-20 h-20 rounded-full bg-teal-300"></div>
+        <div class="w-16 h-16 rounded-full bg-teal-300"></div>
     <% end %>
   </div>
   <div class="card-body pt-2 pl-2 pr-0">


### PR DESCRIPTION
## 概要
* アバター周りの円のサイズがavatar_cssによって変化する分岐の中の一部が縮小サイズに修正できていなかったので修正。