### PR TITLE
update: navの空白を変更

### DIFF
--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,6 +1,5 @@
 <div id="navbarSupportedContent">
   <ul class="flex justify-between mt-3">
-  <div class="grid"><!-- 左端の透明なスペース --></div>
     <li class="nav-item">
       <%= link_to diaries_path, class: "nav-link", id: "home" do %>
         <div class="text-4xl">
@@ -55,6 +54,5 @@
         マイページ
       </div>
     </li>
-  <div class="grid"><!-- 左端の透明なスペース --></div>
   </ul>
 </div>


### PR DESCRIPTION
* _navの上下に入れていた下記の記述を削除して、ナビゲーションバーの空白削除。
```
<div class="grid"><!-- 左端の透明なスペース --></div>
```
* スマホで表示した時に空白があるせいで詰まってるように見えたため。

