### PR TITLE
update: ナビゲーションバー、ヘッダーの要素表示処理をリファクタリング。文字を縮小して位置を真ん中になるようにそれぞれにflex i…

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,4 +43,13 @@ module ApplicationHelper
       # }
     }
   end
+
+  def navbar_link(path, icon_class, text, id)
+    link_to path, class: "nav-link", id: id do
+      content_tag(:div, class: "text-4xl flex items-center justify-center") do
+        content_tag(:i, "", class: icon_class)
+      end +
+      content_tag(:div, text, class: "text-xs flex items-center justify-center")
+    end
+  end
 end

--- a/app/views/diaries/new.html.erb
+++ b/app/views/diaries/new.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:title, t("title.new_diary")) %>
 <%= render partial: "shared/error_messages", locals:{object: @diary} %>
+<div class="text-2xl font-bold flex items-center justify-center">
+  <h1><%= t("title.new_diary") %></h1>
+</div>
 <div class="row">
-  <div class="flex items-center justify-center">
-    <h1><%= t("title.new_diary") %></h1>
-  </div>
   <div class="flex items-center justify-center mx-5">
     <%= render partial: "form", locals:{button: "保存"} %>
   </div>

--- a/app/views/memories/index.html.erb
+++ b/app/views/memories/index.html.erb
@@ -1,4 +1,7 @@
 <% content_for(:title, t("title.memory")) %>
+<div class="text-2xl font-bold flex items-center justify-center">
+  <h1><%= t("title.memory") %></h1>
+</div>
 <%= month_calendar(events: @diaries) do |date, diaries| %>
   <%= date.day %>
   <% diaries.each do |diary| %>

--- a/app/views/ranking/index.html.erb
+++ b/app/views/ranking/index.html.erb
@@ -1,4 +1,7 @@
 <div class="z-40">
+  <div class="text-2xl font-bold flex items-center justify-center">
+    <h1><%= t("title.ranking") %></h1>
+  </div>
   <% if @max_liked_diaries.present? %>
     <div id="diaries">
       <div class="text-2xl flex items-center justify-center">

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -5,25 +5,11 @@
 <div id="navbarSupportedContent">
   <ul class="flex justify-between mt-1 mx-3 w-60">
     <li class="">
-      <%= link_to "/", class: "nav-link", id: "header-menu" do %>
-        <div class="text-4xl">
-          <i class="fa-solid fa-question"></i>
-        </div>
-        <div class="text-sm">
-          使い方
-        </div>
-      <% end %>
+      <%= navbar_link("/", "fa-solid fa-question", "使い方", "header-menu") %>
     </li>
 
     <li class="">
-      <%= link_to new_user_session_path, class: "line-login-link" do %>
-        <div class="text-4xl">
-        <i class="fa-solid fa-right-to-bracket"></i>
-        </div>
-        <div class="text-sm">
-            ログイン
-        </div>
-      <% end %>
+      <%= navbar_link(new_user_session_path, "fa-solid fa-right-to-bracket", "ログイン", "login") %>
     </li>
   </ul>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,14 +6,7 @@
 <div id="navbarSupportedContent">
   <ul class="flex justify-between mt-1 w-60">
     <li class="">
-      <%= link_to "/", class: "nav-link", id: "header-menu" do %>
-        <div class="text-4xl">
-          <i class="fa-solid fa-question"></i>
-        </div>
-        <div class="text-sm">
-          使い方
-        </div>
-      <% end %>
+      <%= navbar_link("/", "fa-solid fa-question", "使い方", "header-menu") %>
     </li>
 
     <li class="">
@@ -56,16 +49,15 @@
     </li>
     <li class="">
       <%= link_to destroy_user_session_path, class: "line-logout-link", data: { turbo_method: :delete } do %>
-        <div class="text-4xl">
+        <div class="text-4xl flex items-center justify-center">
           <i class="fa-solid fa-right-from-bracket"></i>
         </div>
-        <div class="text-sm">
+        <div class="text-sm flex items-center justify-center">
           ログアウト
         </div>
       <% end %>
     </li>
   </ul>
-  <div class="grid"><!-- 左端の透明なスペース --></div>
 </div>
 
 <dialog id="my_modal_3" class="modal">

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,58 +1,23 @@
 <div id="navbarSupportedContent">
   <ul class="flex justify-between mt-3">
     <li class="nav-item">
-      <%= link_to diaries_path, class: "nav-link", id: "home" do %>
-        <div class="text-4xl">
-          <i class="fa-solid fa-tent"></i>
-        </div>
-        <div class="text-sm">
-          ホーム
-        </div>
-      <% end %>
+      <%= navbar_link(diaries_path, "fa-solid fa-tent", "ホーム", "home") %>
     </li>
 
     <li class="nav-item">
-      <%= link_to ranking_path, class: "nav-link", id: "search" do %>
-        <div class="text-4xl">
-          <i class="fa-solid fa-crown"></i>
-        </div>
-        <div class="text-sm">
-          表彰
-        </div>
-      <% end %>
+      <%= navbar_link(ranking_path, "fa-solid fa-crown", "表彰", "search") %>
     </li>
 
     <li class="nav-item">
-      <%= link_to new_diary_path, class: "nav-link", id: "create" do %>
-        <div class="text-4xl">
-          <i class="fa-solid fa-plus"></i>
-        </div>
-        <div class="text-sm">
-          日記作成
-        </div>
-      <% end %>
+      <%= navbar_link(new_diary_path, "fa-solid fa-plus", "日記作成", "create") %>
     </li>
 
-    <li class="nav-item"> 
-      <%= link_to memories_path, class: "nav-link", id: "memory" do %>
-        <div class="text-4xl">
-          <i class="fa-regular fa-calendar-days"></i>
-        </div>
-        <div class="text-sm">
-          思い出
-        </div>
-      <% end %>
+    <li class="nav-item">
+      <%= navbar_link(memories_path, "fa-regular fa-calendar-days", "思い出", "memory") %>
     </li>
 
-    <li class="nav-item"> 
-      <div class="text-4xl">
-        <%= link_to profile_path, class: "nav-link", id: "profile" do %>
-          <i class="fa-solid fa-user"></i>
-        <% end %>
-      </div>
-      <div class="text-xs">
-        マイページ
-      </div>
+    <li class="nav-item">
+      <%= navbar_link(profile_path, "fa-solid fa-user", "マイページ", "profile") %>
     </li>
   </ul>
 </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t("title.login")) %>
-<div class="flex items-center justify-center">
+<div class="text-2xl font-bold flex items-center justify-center">
   <h1><%= t("title.login") %></h1>
 </div>
 <div class="flex items-center justify-center">

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -65,6 +65,7 @@ ja:
   title:
     home: ホーム
     search: 検索
+    ranking: 表彰
     new_diary: 日記作成
     memory: 思い出
     mypage: マイページ


### PR DESCRIPTION
…tems-center justify-centerを追記
## 概要
* ナビゲーションバーやヘッダーのアイコン部分は記述が共通していたため、application_heplerにメソッドを追加してリファクタリング。
* アイコンの下の文字の縮小
* アイコンと文字を中央揃えするには、それぞれの要素にflex items-center justify-centerをつけるしかなさそうなので追記
* 各ページにタイトルが太字で出るように追加