### PR TITLE
add: head要素にgoogleタグを追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,15 @@
     </script>
     <%= favicon_link_tag('favicon.ico') %>
     <%= display_meta_tags(default_meta_tags) %>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-NW1G1830TN"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-NW1G1830TN');
+    </script>
   </head>
 
   <body>


### PR DESCRIPTION
googleアナリティクスによる分析のため、アナリティクスにバズダイアリー用のタグを作成。バズダイアリー側の全てのhead要素にgoogleタグを追加。
railsの場合はapplication.html.erbのhead要素が全てのページで共通なので、そこだけに追加する。