### PR TITLE
update: 一覧のxボタンを条件分岐で表示。トップページ修正。プロフィールの投稿カウント処理調整

### DIFF
--- a/app/controllers/missions_controller.rb
+++ b/app/controllers/missions_controller.rb
@@ -20,25 +20,4 @@ class MissionsController < ApplicationController
       render plain: 'Invalid mission type', status: :bad_request
     end
   end
-
-  private
-
-  def prepare_meta_tags(mission)
-    ## このimage_urlにMiniMagickで設定したOGPの生成した合成画像を代入する
-    image_url = "#{request.base_url}/images/ogp.png?text=#{CGI.escape(mission.title)}"
-    set_meta_tags og: {
-                    site_name: 'バズダイアリー',
-                    title: mission.title,
-                    description: 'ユーザーが達成したチャレンジミッションの共有です',
-                    type: 'website',
-                    url: request.original_url,
-                    image: image_url,
-                    locale: 'ja-JP'
-                  },
-                  twitter: {
-                    card: 'summary_large_image',
-                    site: '@https://x.com/rgoto_51b',
-                    image: image_url
-                  }
-  end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -37,12 +37,20 @@ class ProfilesController < ApplicationController
       elsif diary.created_at.between?((Time.zone.today - (past_count + 1).day).beginning_of_day,
                                       (Time.zone.today - (past_count + 1).day).end_of_day)
         logger.info 'message::::created_at Yesterdays diary was there. OK'
-        past_count += 3
+        if past_count == 0
+          past_count += 2
+        else
+          past_count += 3
+        end
         consecutive_count += 1
       elsif diary.created_at.between?((Time.zone.today - (past_count + 2).day).beginning_of_day,
                                       (Time.zone.today - (past_count + 2).day).end_of_day)
         logger.info 'message::::created_at 2days ago diary was there. OK'
-        past_count += 4
+        if past_count == 0
+          past_count += 3
+        else
+          past_count += 4
+        end
         consecutive_count += 1
       else
         logger.info 'message::::each loop break'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,6 +76,7 @@ class User < ApplicationRecord
                                    (Time.zone.today - past_count.day).end_of_day)
         past_count += 1
         consecutive_count += 1
+        logger.info 'message::count_up'
       elsif diary.created_at.between?((Time.zone.today - (past_count - 1).day).beginning_of_day,
                                       (Time.zone.today - (past_count - 1).day).end_of_day)
         logger.info 'message::::Same created_at and different diary_date...not count up'
@@ -88,6 +89,7 @@ class User < ApplicationRecord
           past_count += 3
         end
         consecutive_count += 1
+        logger.info 'message::count_up'
       elsif diary.created_at.between?((Time.zone.today - (past_count + 2).day).beginning_of_day,
                                       (Time.zone.today - (past_count + 2).day).end_of_day)
         logger.info 'message::::created_at 2days ago diary was there. OK'
@@ -97,6 +99,7 @@ class User < ApplicationRecord
           past_count += 4
         end
         consecutive_count += 1
+        logger.info 'message::count_up'
       else
         logger.info 'message::::each loop break'
         break

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -39,13 +39,15 @@
           </div>
         </div>
       <% end %>
-      <div class="text-gray-600 pt-8">
-        <% app_url = "https://praise-diary.onrender.com/diaries" %>
-        <% twitter_share_url = "https://twitter.com/share?url=#{app_url}&text=%0aバズダイアリーで#{diary.likes_count}いいね ]%0a獲得!%0a%0aバズってます！%0a%0a" %>
-        <%= link_to twitter_share_url, target: '_blank', data: { toggle: "tooltip", placement: "bottom" }, title: "Xで自慢しちゃおう!" do %>
-          <i class="fa-brands fa-x-twitter fa-2xl"></i>
-        <% end %>
-      </div>
+      <% if current_user && current_user.own?(diary) %>
+        <div class="text-gray-600 pt-8">
+          <% app_url = "https://praise-diary.onrender.com/diaries" %>
+          <% twitter_share_url = "https://twitter.com/share?url=#{app_url}&text=%0aバズダイアリーで投稿した日記でなんと・・・%0a#{diary.likes_count}いいね%0a獲得!%0aバズってます！！！%0a" %>
+          <%= link_to twitter_share_url, target: '_blank', data: { toggle: "tooltip", placement: "bottom" }, title: "Xで自慢しちゃおう!" do %>
+            <i class="fa-brands fa-x-twitter fa-2xl"></i>
+          <% end %>
+        </div>
+      <% end %>
       <div class="relative">
         <div class="text-xs">
           <%= l diary.created_at, format: :short %>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -68,12 +68,21 @@
   <p class="my-2 font-bold text-wakatake text-3xl">そしてバズった嬉しさを</p>
   <p class="my-2 font-bold text-wakatake text-3xl">また明日も日記を書きたい！</p>
   <p class="my-2 font-bold text-wakatake text-3xl">に繋げよう</p>
+  <br>
   <div class="text-3xl border-b-4 my-2 text-wakatake">  
     <p>・表彰されよう！</p>
   </div>
   <p class="my-2">すごい日記やユーザーは</p>
   <p class="my-2">表彰メニューで讃えられちゃう！</p>
   <a href="https://gyazo.com/30bf96b0fa383202eb15cc41988a51af"><img src="https://i.gyazo.com/30bf96b0fa383202eb15cc41988a51af.gif" alt="Image from Gyazo" width="280"/></a>
+  <div class="text-3xl border-b-4 my-2 text-wakatake">  
+    <p>・自慢しちゃおう！</p>
+  </div>
+  <p class="my-2">自分のバズり具合はXで自慢しちゃおう！</p>
+  <p class="my-2">Xのマークから投稿できます</p>
+  <a href="https://gyazo.com/02a1219a01176b4e9e5356440e8de697"><img src="https://i.gyazo.com/02a1219a01176b4e9e5356440e8de697.png" alt="Image from Gyazo" width="291"/></a>
+  <a href="https://gyazo.com/fcceeb4de8508c79637dc8158ac7e8ff"><img src="https://i.gyazo.com/fcceeb4de8508c79637dc8158ac7e8ff.png" alt="Image from Gyazo" width="239"/></a>
+  <br>
   <div class="text-3xl border-b-4 my-2 text-wakatake">  
     <p>・公式アカウントを</p>
   </div>
@@ -84,6 +93,7 @@
   <p class="my-2">LINE通知をONにすると</p>
   <p class="my-2">忘れずに日記を書けますよ！</p>
   <a href="https://gyazo.com/f4aa2c98b452bf88cd4bb62f782d48c1"><img src="https://i.gyazo.com/f4aa2c98b452bf88cd4bb62f782d48c1.gif" alt="Image from Gyazo" width="276"/></a>
+  <br>
   <div class="text-3xl border-b-4 my-2 text-wakatake">  
     <p>バズダイアリーを</p>
   </div>


### PR DESCRIPTION
## 概要
* 一覧ページのxボタンの表示を、ログインしているユーザーで、自分の日記の場合。という条件に一致した場合に行うように修正。日記詳細の編集・削除ボタンと同じ条件。
* xボタンで自慢する機能があることをトップページに説明追加
* マイページメニューでの連続投稿数カウント処理も修正