### PR TITLE
fix: カウント処理を元に戻した

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -24,36 +24,69 @@ class ProfilesController < ApplicationController
   def number_of_consecutive_days
     past_count = 0
     consecutive_count = 0
-    grace_period = 2 # 猶予は2日間
     my_diaries = current_user.diaries.order(created_at: :desc)
-    
     my_diaries.each do |diary|
       logger.info "message::::diary: #{diary.inspect}"
-  
-      # 現在の past_count に該当する日付で投稿があるかを確認
       if diary.created_at.between?((Time.zone.today - past_count.day).beginning_of_day,
-                                   (Time.zone.today - past_count.day).end_of_day)
+                                   (Time.zone.today - past_count.day).end_of_day) && diary.created_at.to_date == diary.diary_date
         past_count += 1
         consecutive_count += 1
-        logger.info 'message::count_up'
-        logger.info "message::past_count #{past_count}"
-  
-      # 猶予期間内の投稿かを確認（1日または2日途絶えた場合）
+      elsif diary.created_at.between?((Time.zone.today - past_count.day).beginning_of_day,
+                                      (Time.zone.today - past_count.day).end_of_day) && diary.created_at.to_date != diary.diary_date
+        logger.info 'message::::Same created_at and different diary_date...not count up & past_count up'
       elsif diary.created_at.between?((Time.zone.today - (past_count + 1).day).beginning_of_day,
-                                      (Time.zone.today - (past_count + grace_period).day).end_of_day)
-        # 猶予内に投稿があれば連続カウントを増加
-        days_skipped = (Time.zone.today.to_date - diary.created_at.to_date).to_i
-        past_count += days_skipped
+                                      (Time.zone.today - (past_count + 1).day).end_of_day) && diary.created_at.to_date == diary.diary_date
+        logger.info 'message::::created_at Yesterdays diary was there. OK'
+        past_count += 2
         consecutive_count += 1
-        logger.info "message::count_up with grace period"
-        logger.info "message::past_count after grace period: #{past_count}"
-  
-      # 3日以上空いた場合はループを終了
+      elsif diary.created_at.between?((Time.zone.today - (past_count + 2).day).beginning_of_day,
+                                      (Time.zone.today - (past_count + 2).day).end_of_day) && diary.created_at.to_date == diary.diary_date
+        logger.info 'message::::created_at 2days ago diary was there. OK'
+        past_count += 3
+        consecutive_count += 1
       else
-        logger.info 'message::::Break due to more than 2 days of inactivity'
+        logger.info 'message::::each loop break'
         break
       end
     end
     consecutive_count
   end
+
+  # def number_of_consecutive_days
+  #   past_count = 0
+  #   consecutive_count = 0
+  #   grace_period = 2 # 猶予は2日間
+  #   my_diaries = current_user.diaries.order(created_at: :desc)
+    
+  #   my_diaries.each do |diary|
+  #     logger.info "message::::diary: #{diary.inspect}"
+  
+  #     # 現在の past_count に該当する日付で投稿があるかを確認
+  #     if diary.created_at.between?((Time.zone.today - past_count.day).beginning_of_day,
+  #                                  (Time.zone.today - past_count.day).end_of_day)
+  #       past_count += 1
+  #       consecutive_count += 1
+  #       logger.info 'message::count_up'
+  #       logger.info "message::past_count #{past_count}"
+  
+  #     # 猶予期間内の投稿かを確認（1日または2日途絶えた場合）
+  #     elsif diary.created_at.between?((Time.zone.today - (past_count + 1).day).beginning_of_day,
+  #                                     (Time.zone.today - (past_count + grace_period).day).end_of_day)
+  #       # 猶予内に投稿があれば連続カウントを増加
+  #       logger.info "message::#{(Time.zone.today - (past_count + 1).day).beginning_of_day}"
+  #       logger.info "message::#{(Time.zone.today - (past_count + grace_period).day).end_of_day}"
+  #       days_skipped = (Time.zone.today.to_date - diary.created_at.to_date).to_i
+  #       past_count += days_skipped
+  #       consecutive_count += 1
+  #       logger.info "message::count_up with grace period"
+  #       logger.info "message::past_count after grace period: #{past_count}"
+  
+  #     # 3日以上空いた場合はループを終了
+  #     else
+  #       logger.info 'message::::Break due to more than 2 days of inactivity'
+  #       break
+  #     end
+  #   end
+  #   consecutive_count
+  # end
 end


### PR DESCRIPTION
## 概要
* カウント処理を元に戻しつつ、条件分岐にcreated_atの日付とdiary_dateが一致しているかを&&処理で追加した。