### PR TITLE
fix: カウント処理修正

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -36,7 +36,6 @@ class ProfilesController < ApplicationController
           logger.info "message:: count up #{consecutive_count}"
           logger.info "message:: count up past #{past_count}"
         else
-          past_count += 1
           logger.info 'message:: but different diary_date...not count up'
         end
 # 最後にカウントアップ処理をしたレコードと同じcreated_at.to_dateかどうか検証。
@@ -61,7 +60,6 @@ class ProfilesController < ApplicationController
           logger.info "message:: count up #{consecutive_count}"
           logger.info "message:: count up past #{past_count}"
         else
-          past_count += 1
           logger.info 'message:: but different diary_date...not count up'
         end
 # 2日空いた後に日記があるかを確認。カウントが進むことを許容する。
@@ -74,7 +72,6 @@ class ProfilesController < ApplicationController
           logger.info "message:: count up #{consecutive_count}"
           logger.info "message:: count up past #{past_count}"
         else
-          past_count += 2
           logger.info 'message:: but different diary_date...not count up'
         end
       else


### PR DESCRIPTION
## 概要
* created_atと検証している日付が一致したけど、diary_dateが一致しない時、何もしないように処理を変更。
* これにより、一致しなかったときは次のレコードも同じ条件で見ることができるようになった。
* 今までは一致しなかった時になぜかpast_countを進めていたので、どんどん離れていってしまっていた。