### PR TITLE
fix: configの記述をするとアクセスできなくなるのでそこだけ戻す

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -97,5 +97,5 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
-  config.hosts << 'www.buzzdiaries.com'
+  # config.hosts << 'www.buzzdiaries.com'
 end


### PR DESCRIPTION
production.rbにconfigの記述をしているとアクセスできないっぽい。そこだけコメントアウトして、他のURLとかは独自ドメインにする。