### PR TITLE
fix:日記詳細の文章が改行で見づらい問題を解消。ハートとカウントの位置調整

### DIFF
--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -35,7 +35,7 @@
             <% end %>
           </div>
           <div class="card-title text-xs">
-            <%= truncate(diary.body, length: 15, omission: '...') %>
+            <%= truncate(diary.title, length: 15, omission: '...') %>
           </div>
         </div>
       <% end %>
@@ -48,52 +48,54 @@
           <% end %>
         </div>
       <% end %>
-      <div class="relative">
+      <div id="other">
         <div class="text-xs">
           <%= l diary.created_at, format: :short %>
         </div>
-        <div id="like-<%=diary.id%>" class="flex right-0.5">
-          <%= button_to likes_path(diary_id: diary.id), id: "btn_animation", method: { turbo_method: :post } do %>
-            <% if diary.likes_count >= 0 && diary.likes_count < 500 %>
-              <div class="btn0">
-            <% elsif diary.likes_count >= 500 && diary.likes_count < 1000 %>
-              <div class="btn1">
-            <% elsif diary.likes_count >= 1000 && diary.likes_count < 10000 %>
-              <div class="btn2">
-            <% else %>
-              <div class="btn3">
-            <% end %>
-              <% case diary.user.like_css %>
-              <% when 0 %>
-                <i class="fa-solid fa-heart text-5xl pt-2 text-green-500"></i>
-              <% when 1 %>
-                <i class="fa-solid fa-heart text-5xl pt-2 text-yellow-400"></i>
-              <% when 2 %>
-                <i class="fa-solid fa-heart text-5xl pt-2 text-sky-500"></i>
-              <% when 3 %>
-                <i class="fa-solid fa-heart text-5xl pt-2 text-rose-600"></i>
-              <% when 4 %>
-                <i class="fa-solid fa-heart text-5xl pt-2 text-fuchsia-700"></i>
-              <% when 5 %>
-                <i class="fa-solid fa-heart text-5xl pt-2 text-teal-300"></i>
-              <% end %>
-            </div>
-            <div id="count-<%= diary.id %>">
-              <% if diary.likes_count >= 0 && diary.likes_count < 10 %>
-                <div class="absolute text-black top-8 left-5">
-              <% elsif diary.likes_count >= 10 && diary.likes_count < 100 %>
-                <div class="absolute text-black top-8 left-4">
-              <% elsif diary.likes_count >= 100 && diary.likes_count < 1000 %>
-                <div class="absolute text-black top-8 left-2">
+        <div class="relative">
+          <div id="like-<%=diary.id%>" class="flex right-0.5">
+            <%= button_to likes_path(diary_id: diary.id), id: "btn_animation", method: { turbo_method: :post } do %>
+              <% if diary.likes_count >= 0 && diary.likes_count < 500 %>
+                <div class="btn0">
+              <% elsif diary.likes_count >= 500 && diary.likes_count < 1000 %>
+                <div class="btn1">
               <% elsif diary.likes_count >= 1000 && diary.likes_count < 10000 %>
-                <div class="absolute text-black top-8 left-1">
+                <div class="btn2">
               <% else %>
-                <div class="absolute text-black top-8 left-0">
+                <div class="btn3">
               <% end %>
-                <h2><%= diary.likes_count || 0 %></h2>
+                <% case diary.user.like_css %>
+                <% when 0 %>
+                  <i class="fa-solid fa-heart text-5xl pt-2 text-green-500"></i>
+                <% when 1 %>
+                  <i class="fa-solid fa-heart text-5xl pt-2 text-yellow-400"></i>
+                <% when 2 %>
+                  <i class="fa-solid fa-heart text-5xl pt-2 text-sky-500"></i>
+                <% when 3 %>
+                  <i class="fa-solid fa-heart text-5xl pt-2 text-rose-600"></i>
+                <% when 4 %>
+                  <i class="fa-solid fa-heart text-5xl pt-2 text-fuchsia-700"></i>
+                <% when 5 %>
+                  <i class="fa-solid fa-heart text-5xl pt-2 text-teal-300"></i>
+                <% end %>
               </div>
-            </div>
-          <% end %>
+              <div id="count-<%= diary.id %>">
+                <% if diary.likes_count >= 0 && diary.likes_count < 10 %>
+                  <div class="absolute text-black top-5 left-5">
+                <% elsif diary.likes_count >= 10 && diary.likes_count < 100 %>
+                  <div class="absolute text-black top-5 left-4">
+                <% elsif diary.likes_count >= 100 && diary.likes_count < 1000 %>
+                  <div class="absolute text-black top-5 left-2">
+                <% elsif diary.likes_count >= 1000 && diary.likes_count < 10000 %>
+                  <div class="absolute text-black top-5 left-1">
+                <% else %>
+                  <div class="absolute text-black top-5 left-0">
+                <% end %>
+                  <h2><%= diary.likes_count || 0 %></h2>
+                </div>
+              </div>
+            <% end %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/diaries/_show_diary.html.erb
+++ b/app/views/diaries/_show_diary.html.erb
@@ -1,5 +1,5 @@
 <article class="card my-9">
-  <div class="chat chat-start w-72">
+  <div class="chat chat-start w-96">
     <div class="avatar pt-1 relative">
       <div class="w-10 h-10 rounded-full absolute top-2 left-1">
         <% if diary.user.image.present? %>
@@ -24,9 +24,9 @@
       <% end %>
     </div>
     <div class="chat-bubble bg-white text-black">
-      <div class="card-body pt-2">
+      <div class="card-body pt-2 px-0">
         <div class="flex">
-          <div class="card-diary-date text-xs">
+          <div class="card-diary-date">
             <%=diary.diary_date %><br>
             <%= t("diaries.diary_date") %>
           </div>
@@ -37,9 +37,69 @@
         <div class="card-text text-base">
           <%= diary.body.scan(/.{1,15}/).join("<br>").html_safe %>
         </div>
-        <div class="text-xs text-gray-400">
-        作成日時：<br>
-        <%= l diary.created_at, format: :short %>
+        <div class="flex justify-between">
+          <div class="text-gray-400 pr-5">
+            <div class="text-xs">
+              作成日時：<br>
+              <%= l diary.created_at, format: :short %>
+            </div>
+            <% if current_user && current_user.own?(diary) %>
+              <div class="action pt-3">
+                <%= link_to edit_diary_path(diary.id), id: "edit", class: "edit-comment-link" do %>
+                  <i class="fa-regular fa-pen-to-square text-base"></i>
+                <% end %>
+                <%= link_to diary_path(diary.id), id: "destroy", class: "destroy-comment-link", data: { turbo_method: :delete , turbo_confirm: t('defaults.delete_confirm') } do %>
+                  <i class="fa-regular fa-trash-can text-base"></i>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+          <div class="relative">
+            <div id="like-<%=diary.id%>">
+              <%= button_to likes_path(diary_id: diary.id), id: "btn_animation", method: { turbo_method: :post } do %>
+                <% if diary.likes_count >= 0 && diary.likes_count < 500 %>
+                  <div class="btn0">
+                <% elsif diary.likes_count >= 500 && diary.likes_count < 1000 %>
+                  <div class="btn1">
+                <% elsif diary.likes_count >= 1000 && diary.likes_count < 10000 %>
+                  <div class="btn2">
+                <% else %>
+                  <div class="btn3">
+                <% end %>
+                <% case diary.user.like_css %>
+                <% when 0 %>
+                  <i class="fa-solid fa-heart text-5xl pt-2 text-green-500"></i>
+                <% when 1 %>
+                  <i class="fa-solid fa-heart text-5xl pt-2 text-yellow-400"></i>
+                <% when 2 %>
+                  <i class="fa-solid fa-heart text-5xl pt-2 text-sky-500"></i>
+                <% when 3 %>
+                  <i class="fa-solid fa-heart text-5xl pt-2 text-rose-600"></i>
+                <% when 4 %>
+                  <i class="fa-solid fa-heart text-5xl pt-2 text-fuchsia-700"></i>
+                <% when 5 %>
+                  <i class="fa-solid fa-heart text-5xl pt-2 text-teal-300"></i>
+                <% end %>
+                </div>
+                <div id="count-<%= diary.id %>">
+                  <% if diary.likes_count >= 0 && diary.likes_count < 10 %>
+                    <div class="absolute text-black top-5 left-5">
+                  <% elsif diary.likes_count >= 10 && diary.likes_count < 100 %>
+                    <div class="absolute text-black top-5 left-4">
+                  <% elsif diary.likes_count >= 100 && diary.likes_count < 1000 %>
+                    <div class="absolute text-black top-5 left-2">
+                  <% elsif diary.likes_count >= 1000 && diary.likes_count < 10000 %>
+                    <div class="absolute text-black top-5 left-1">
+                  <% else %>
+                    <div class="absolute text-black top-5 left-0">
+                  <% end %>
+                    <h2><%= diary.likes_count || 0 %></h2>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -51,59 +111,3 @@
     </div>
   <% end %>
 </article>
-
-<div class="relative mb-12">
-  <% if current_user && current_user.own?(diary) %>
-    <div class="action">
-      <%= link_to edit_diary_path(diary.id), id: "edit", class: "edit-comment-link" do %>
-        <i class="fa-regular fa-pen-to-square"></i>
-      <% end %>
-      <%= link_to diary_path(diary.id), id: "destroy", class: "destroy-comment-link", data: { turbo_method: :delete , turbo_confirm: t('defaults.delete_confirm') } do %>
-        <i class="fa-regular fa-trash-can"></i>
-      <% end %>
-    </div>
-  <% end %>
-  <div id="like-<%=diary.id%>">
-    <%= button_to likes_path(diary_id: diary.id), id: "btn_animation", method: { turbo_method: :post } do %>
-      <% if diary.likes_count >= 0 && diary.likes_count < 500 %>
-        <div class="btn0">
-      <% elsif diary.likes_count >= 500 && diary.likes_count < 1000 %>
-        <div class="btn1">
-      <% elsif diary.likes_count >= 1000 && diary.likes_count < 10000 %>
-        <div class="btn2">
-      <% else %>
-        <div class="btn3">
-      <% end %>
-      <% case diary.user.like_css %>
-      <% when 0 %>
-        <i class="fa-solid fa-heart text-5xl pt-2 text-green-500"></i>
-      <% when 1 %>
-        <i class="fa-solid fa-heart text-5xl pt-2 text-yellow-400"></i>
-      <% when 2 %>
-        <i class="fa-solid fa-heart text-5xl pt-2 text-sky-500"></i>
-      <% when 3 %>
-        <i class="fa-solid fa-heart text-5xl pt-2 text-rose-600"></i>
-      <% when 4 %>
-        <i class="fa-solid fa-heart text-5xl pt-2 text-fuchsia-700"></i>
-      <% when 5 %>
-        <i class="fa-solid fa-heart text-5xl pt-2 text-teal-300"></i>
-      <% end %>
-      </div>
-      <div id="count-<%= diary.id %>">
-        <% if diary.likes_count >= 0 && diary.likes_count < 10 %>
-          <div class="absolute text-black top-8 left-5">
-        <% elsif diary.likes_count >= 10 && diary.likes_count < 100 %>
-          <div class="absolute text-black top-8 left-4">
-        <% elsif diary.likes_count >= 100 && diary.likes_count < 1000 %>
-          <div class="absolute text-black top-8 left-2">
-        <% elsif diary.likes_count >= 1000 && diary.likes_count < 10000 %>
-          <div class="absolute text-black top-8 left-1">
-        <% else %>
-          <div class="absolute text-black top-8 left-0">
-        <% end %>
-          <h2><%= diary.likes_count || 0 %></h2>
-        </div>
-      </div>
-    <% end %>
-  </div>
-</div>

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -27,15 +27,15 @@
       </div>
       <div id="count-<%= @diary.id %>">
         <% if @diary.likes_count >= 0 && @diary.likes_count < 10 %>
-          <div class="absolute text-black top-8 left-5">
+          <div class="absolute text-black top-5 left-5">
         <% elsif @diary.likes_count >= 10 && @diary.likes_count < 100 %>
-          <div class="absolute text-black top-8 left-4">
+          <div class="absolute text-black top-5 left-4">
         <% elsif @diary.likes_count >= 100 && @diary.likes_count < 1000 %>
-          <div class="absolute text-black top-8 left-2">
+          <div class="absolute text-black top-5 left-2">
         <% elsif @diary.likes_count >= 1000 && @diary.likes_count < 10000 %>
-          <div class="absolute text-black top-8 left-1">
+          <div class="absolute text-black top-5 left-1">
         <% else %>
-          <div class="absolute text-black top-8 left-0">
+          <div class="absolute text-black top-5 left-0">
         <% end %>
           <h2><%= @diary.likes_count || 0 %></h2>
         </div>


### PR DESCRIPTION
## 概要
* 日記詳細ページが15文字ごとに改行するような記述をしているが、吹き出しの枠幅が短すぎたことで15文字に達する前に改行になってしまい、文として見づらいものになっていた。
* チャットバブルのパディング幅が大きいことが問題だと分かったため、px-0を追加して調整。
* また、チャットバブルそのものの幅が短いのも原因だったため、w-72からw-96に修正
* いいね数とハートの重ね合わせ位置調整の数値(例：absolute top-8 left-4)について、日記一覧と詳細のrelative位置がずれていたため、うまく統一できていなかったが、relative以下にいいね数とハート以外の要素を入れないことで統一できた。

## 変更前
![image](https://github.com/user-attachments/assets/623daa40-8ab8-4368-bca5-213f0bbebf85)

## 変更後
![image](https://github.com/user-attachments/assets/2b2abeb3-e647-425d-aa95-0e13006d247d)
