### PR TITLE
test: rubocop対応。rspecの文字数等のチェック外し

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,15 @@ require:
 
 Style/Documentation:
   Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Enabled: false
+
+RSpec/ContextWording:
+  Enabled: false


### PR DESCRIPTION
## 概要
* rubocopのrspecに関するチェックを外すための記述を.rubocop.ymlに追記
* 現在のrubocop結果は以下
```
118 files inspected, 13 offenses detected, 4 offenses autocorrectable
```