### PR TITLE
Rubocop fix all

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,6 @@ Rails/NotNullColumn:
 
 Rails/BulkChangeTable:
   Enabled: false
+
+Rails/LexicallyScopedActionFilter:
+  Enabled: false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[line] # for line-login
@@ -23,7 +21,7 @@ class User < ApplicationRecord
 
   # for line-login
   def social_profile(provider)
-    social_profiles.select { |sp| sp.provider == provider.to_s }.first
+    social_profiles.find { |sp| sp.provider == provider.to_s }
   end
 
   def set_values(omniauth)
@@ -37,7 +35,6 @@ class User < ApplicationRecord
     credentials.to_json
     info['name']
     info['image']
-    # self.set_values_by_raw_info(omniauth['extra']['raw_info'])
   end
 
   def set_values_by_raw_info(raw_info)
@@ -82,8 +79,7 @@ class User < ApplicationRecord
         if diary.created_at.to_date == diary.diary_date
           past_count += 1
           consecutive_count += 1
-          logger.info "message:: count up #{consecutive_count}"
-          logger.info "message:: count up past #{past_count}"
+          logger.info "message:: past >> #{past_count}, consecutive >> #{consecutive_count}"
         else
           logger.info 'message:: but different diary_date...not count up'
         end
@@ -94,8 +90,7 @@ class User < ApplicationRecord
         logger.info 'message:: Same created_at as the previous record'
         if diary.created_at.to_date == diary.diary_date
           consecutive_count += 1
-          logger.info "message:: count up #{consecutive_count}"
-          logger.info "message:: count up past #{past_count}"
+          logger.info "message:: past >> #{past_count}, consecutive >> #{consecutive_count}"
         else
           logger.info 'message:: but different diary_date...not count up & past_count'
         end
@@ -106,8 +101,7 @@ class User < ApplicationRecord
         if diary.created_at.to_date == diary.diary_date
           past_count += 2
           consecutive_count += 1
-          logger.info "message:: count up #{consecutive_count}"
-          logger.info "message:: count up past #{past_count}"
+          logger.info "message:: past >> #{past_count}, consecutive >> #{consecutive_count}"
         else
           logger.info 'message:: but different diary_date...not count up'
         end
@@ -118,8 +112,7 @@ class User < ApplicationRecord
         if diary.created_at.to_date == diary.diary_date
           past_count += 3
           consecutive_count += 1
-          logger.info "message:: count up #{consecutive_count}"
-          logger.info "message:: count up past #{past_count}"
+          logger.info "message:: past >> #{past_count}, consecutive >> #{consecutive_count}"
         else
           logger.info 'message:: but different diary_date...not count up'
         end
@@ -128,8 +121,7 @@ class User < ApplicationRecord
         break
       end
     end
-    logger.info "message::::past_count: #{past_count}"
-    logger.info "message::::consecutive_count: #{consecutive_count}"
+    logger.info "message:: past >> #{past_count}, past >> #{consecutive_count}"
     consecutive_count
   end
 
@@ -196,8 +188,6 @@ class User < ApplicationRecord
   def add_buff(daily: 0, challenge: 0, mission: nil)
     logger.debug 'message::::add_buff executed'
     logger.debug "self: #{self}"
-    logger.debug "self.buff: #{buff}"
-
     updated = false
 
     if daily.positive?
@@ -258,7 +248,6 @@ class User < ApplicationRecord
     Net::HTTP::Get.new(uri)
     headers = { 'Authorization' => "Bearer #{access_token}" }
     response = http.get(uri.path, headers)
-    # logger.info "message::::access_token: #{access_token}"
     response.code # status code
     response.body # response body
     logger.info "message::::response.code: #{response.code}"

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -7,7 +7,7 @@ CarrierWave.configure do |config|
     aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
     region: 'ap-northeast-1'
   }
-  config.cache_dir = "#{Rails.root.join('tmp/uploads')}"
+  config.cache_dir = Rails.root.join('tmp/uploads').to_s
   config.fog_directory = ENV['DIRECTORY_NAME']
   config.storage = :fog
   config.fog_public = false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,5 +23,5 @@ User.ids
 10.times do |index|
   user = User.find(11)
   diary = user.diaries.create!(title: "今日は連勤#{index}日目だった", body: "まだまだ#{index}日ぐらい頑張れそう！", diary_date: Time.zone.today)
-  puts "\"#{diary.title}\" has created!"
+  logger.info "\"#{diary.title}\" has created!"
 end


### PR DESCRIPTION
## 概要
* 残り全てのrubocop指摘を対応
* Use find instead of select.first.はその通り以下修正
```
  # for line-login
  def social_profile(provider)
    social_profiles.select { |sp| sp.provider == provider.to_s }.first
  end
  
  ↓これをこう修正
  
  # for line-login
  def social_profile(provider)
    social_profiles.find { |sp| sp.provider == provider.to_s }
  end
```
* Class has too many lines. [223/221]は、デバッグ用コメントでパラメータごとに実行していたのを、一つのコメント内に複数のパラメータを表示するように修正することで実行コマンド数を省略して対応
* create is not explicitly defined on the class.は、deviseのgemを使っている以上、sessions_controller.rb上にcreateアクションが無いのは仕方ない上、空のcreateアクションを定義しても別の指摘をされるため、無視する記述をymlファイルに追加して対応

rubocopの現状指摘は全て対応
```
Inspecting 122 files
..........................................................................................................................

122 files inspected, no offenses detected
```